### PR TITLE
Fixed tracking station selecting vessel when terminating mission or sorting the list

### DIFF
--- a/Source/BetterTracking/Tracking_Controller.cs
+++ b/Source/BetterTracking/Tracking_Controller.cs
@@ -193,6 +193,10 @@ namespace BetterTracking
 
             _VesselToggleGroup = Instantiate(_TrackingStation.listToggleGroup);
 
+            GameObject dummyObj = new GameObject("dummy", typeof(Toggle));
+            Toggle dummyToggle = dummyObj.GetComponent<Toggle>();
+            dummyToggle.group = _VesselToggleGroup;
+
             _OldTrackingList = _TrackingStation.listContainer.gameObject;
 
             _NewTrackingList = Instantiate(_OldTrackingList);


### PR DESCRIPTION
Double clicking the sort buttons in the tracking station selects a vessel. Doing it again while that vessel is selected enters flight, but causes a bunch of errors, like the HUD not going away after exiting the flight. This happens in the Default mode if there's more than one vessel, and in Body and Vessel type mode if there's more than one group, for example Kerbin and Duna or Ship and Station. Terminating a mission selects a vessel as well, as it does in vanilla, but the errors are caused by the toggled button being destroyed in the ClearUI method.

I don't know Unity that well, but I think this is because allowSwitchOff is false on the toggle group. Adding an invisible toggle fixes this. I don't know if this is the best way to do it, but I haven't found any problems yet. It also seems to make selecting a vessel work more consistently.